### PR TITLE
Add week1 marker for Flash-as-CTP shield study

### DIFF
--- a/flashsubdoc.txt
+++ b/flashsubdoc.txt
@@ -1,5 +1,6 @@
 flashsubdoc.itisatrap.org/
 nightly.flashstudy.example.com/
+week1.flashstudy.example.com/
 103092804.com/
 1rx.io/
 247realmedia.com/


### PR DESCRIPTION
This adds the week1 sentinel value so that the shield study can classify people as being part of week 1.