### PR TITLE
Copy infobar list to a filename matching new list

### DIFF
--- a/flashinfobar.txt
+++ b/flashinfobar.txt
@@ -1,0 +1,1 @@
+infobarexception.flashblock.itisatrap.org/


### PR DESCRIPTION
The infobar list is being renamed from except-infobars-digest256 to
except-flashinfobar-digest256. To better match the new name, the file
containing the list will also be renamed. However, to allow a seemless
change over from the old file to the new one, the old one will first be
copied to the new one, then removed after the old one is no longer in use.