### PR TITLE
Bug 1422174 - Remove "salesforce.com" from the flashsubdoc blocklist. r=bytesized

### DIFF
--- a/flashsubdoc.txt
+++ b/flashsubdoc.txt
@@ -1804,7 +1804,6 @@ sabrehospitality.com/
 safecount.net/
 sageanalyst.net/
 sagemetrics.com/
-salesforce.com/
 samurai-factory.jp/
 sapient.com/
 sas.com/


### PR DESCRIPTION
This is causing problems for some legitimate salesforce tools.