### PR TITLE
add mapi.3igames.mail.ru to subdoc exceptions

### DIFF
--- a/flashsubdocexceptions.txt
+++ b/flashsubdocexceptions.txt
@@ -1,1 +1,2 @@
 except.flashsubdoc.itisatrap.org/
+mapi.3igames.mail.ru/


### PR DESCRIPTION
3igames.mail.ru is the publishing platform for online games (flash mostly). That platform is also used as a bridge for a game to other sites (like vk.com, odnoklassniki.ru, my.mail.ru, and others). So document containing flash plugin belongs to another document on domain mapi.3igames.mail.ru that belongs to the final destination domain (3igames.mail.ru, vk.com, odnoklassniki.ru, etc).

And mapi.3igames.mail.ru blocked by wildcard mail.ru domain from list flashsubdoc.txt

Please, add mapi.3igames.mail.ru to flashsubdocexceptions.txt to allow online players play flash content in Firefox.
