### PR TITLE
Whitelist Frozen Shard's Facebook games

### DIFF
--- a/flashsubdocexceptions.txt
+++ b/flashsubdocexceptions.txt
@@ -1,2 +1,3 @@
 except.flashsubdoc.itisatrap.org/
+d1qzmgnbw7y2pl.cloudfront.net/
 mapi.3igames.mail.ru/


### PR DESCRIPTION
@felipc, can you please review this flashsubdocexception whitelist change? This is the Facebook game we discussed last Friday.

Frozen Shard's Facebook games load Flash from https://d1qzmgnbw7y2pl.cloudfront.net/, which is blocked by our flashsubdoc blocklist. We can whitelist Frozen Shard's cloudfront subdomain so their Flash loader is click-to-activate instead of hard blocked. Even if Frozen Shared's cloudfront domain expires and is later hijacked someone else, the risk of using this whitelisted subdomain to distribute drive-by Flash malware is low because Flash content will still be click-to-activate.

Frozen Shard is also investigating whether they can move their Flash games to a different domain that is not blocked.

https://apps.facebook.com/wwiitcg/
https://apps.facebook.com/monsterstcg/
https://apps.facebook.com/mythologiestcg/
https://apps.facebook.com/magicquesttcg/